### PR TITLE
Adding top level args override so that we can pass the request on in the request body

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### v2.0.1
+    - Adding top level args override so that we can pass the request on in the request body
+
 ### v2.0.0
     - QueryPaginationResponse will correctly parse datetime and date objects into python datetime objects. Timestamp objects will be left as strings.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rockset"
-version = "2.0.0"
+version = "2.0.1"
 description = "The python client for the Rockset API."
 authors = ["Rockset <support@rockset.com>"]
 packages = [

--- a/rockset/rockset_client.py
+++ b/rockset/rockset_client.py
@@ -75,6 +75,10 @@ def wrapper(method):
                 ) from e
 
             other_args[body_param_name] = body
+        if "add_raw_args_to_body" in other_args:
+            for raw_key, raw_value in other_args["add_raw_args_to_body"].items():
+                other_args[body_param_name][raw_key] = raw_value
+            del other_args["add_raw_args_to_body"]
 
         return method(*args, **other_args)
 

--- a/rockset/rockset_client.py
+++ b/rockset/rockset_client.py
@@ -75,6 +75,9 @@ def wrapper(method):
                 ) from e
 
             other_args[body_param_name] = body
+
+        # A way to pass in arguments that will make it to the body.
+        # This is not officially supported, arguments sent in this way have no compatability gaurentees.
         if "add_raw_args_to_body" in other_args:
             for raw_key, raw_value in other_args["add_raw_args_to_body"].items():
                 other_args[body_param_name][raw_key] = raw_value


### PR DESCRIPTION
Now you can construct a request to add in extra arguments to the request body.  This is not officially supported as these arguments can always change.