### PR TITLE
Stop using deprecated `getheader` method

### DIFF
--- a/rockset/rest.py
+++ b/rockset/rest.py
@@ -39,7 +39,7 @@ class RESTResponse(io.IOBase):
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTPResponse.headers.get(name, default).