### PR TITLE
Fix query example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ import rockset
 
 rs = rockset.RocksetClient(host=rockset.Regions.use1a1, api_key="APIKEY")
 try:
-    res = rs.sql(query="SELECT * FROM _events WHERE kind=:event_type LIMIT 100", params={"event_type", "INGEST"})
+    res = rs.sql(query="SELECT * FROM _events WHERE kind=:event_type LIMIT 100", params={"event_type": "INGEST"})
 except rockset.ApiException as e:
     print("Exception when querying: %s\n" % e)
 ```
@@ -438,4 +438,3 @@ The RocksetClient object must be instantiated with an apikey. You can create you
 ## Author
 
 Rockset
-


### PR DESCRIPTION
`{"event_type", "INGEST"}` is a set whereas `{"event_type: "INGEST"}` is a dict