### PR TITLE
Fix empty params bug in sql convenience method

### DIFF
--- a/rockset/rockset_client.py
+++ b/rockset/rockset_client.py
@@ -269,7 +269,7 @@ class RocksetClient:
 
     def sql(self, query: str, params: Dict[str, Any] = None) -> QueryResponse:
         """Convenience method for making queries."""
-        if params:
+        if params is not None:
             params = [
                 QueryParameter(
                     name=param, value=str(val), type=convert_to_rockset_type(val)


### PR DESCRIPTION
Before this change, `rs.sql("SELECT 1", params={})` failed because empty dicts are Falsy values. `rs.sql` converted `params` to list form only `if params`. However, it should do it `if params is not None`, to make sure empty dicts get converted into lists too. Otherwise, you get the following error:

```
rockset.exceptions.ApiTypeError: Invalid type for variable 'parameters'. Required value type is one of [NoneType, list] and passed type was dict at ['parameters']
```

By the way, this change is necessary because [superset](https://rockset.com/docs/apache-superset/) passes an empty dict as `params` to `rs.sql` if there are no query parameters, currently causing the error above.