### PR TITLE
track application along with client in User-Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# Intellij
+.idea

--- a/rockset/api_client.py
+++ b/rockset/api_client.py
@@ -97,6 +97,9 @@ class ApiClient(object):
     def user_agent(self, value):
         self.default_headers['User-Agent'] = value
 
+    def set_application(self, value):
+        self.default_headers['User-Agent'] = self.user_agent if not value else self.user_agent + ':' + value
+
     def set_default_header(self, header_name, header_value):
         self.default_headers[header_name] = header_value
 

--- a/rockset/rockset_client.py
+++ b/rockset/rockset_client.py
@@ -272,6 +272,9 @@ class RocksetClient:
         self.VirtualInstances = VirtualInstancesApiWrapper(self.api_client)
         self.Workspaces = WorkspacesApiWrapper(self.api_client)
 
+    def set_application(self, value):
+        self.api_client.set_application(value)
+
     def sql(self, query: str, params: Dict[str, Any] = None) -> QueryResponse:
         """Convenience method for making queries."""
         if params is not None:

--- a/templates/api_client.mustache
+++ b/templates/api_client.mustache
@@ -89,6 +89,9 @@ class ApiClient(object):
     def user_agent(self, value):
         self.default_headers['User-Agent'] = value
 
+    def set_application(self, value):
+        self.default_headers['User-Agent'] = self.user_agent if not value else self.user_agent + ':' + value
+
     def set_default_header(self, header_name, header_value):
         self.default_headers[header_name] = header_value
 


### PR DESCRIPTION
Add a helper to set application when integrating with open source tools, sqlalchemy etc to specify the driver driver application. On the server side we already parse this correctly and expose metrics. Plan to use this for an integration usage following merge